### PR TITLE
Have the module wait during transmissions

### DIFF
--- a/Assets/reverseMorseScript.cs
+++ b/Assets/reverseMorseScript.cs
@@ -853,6 +853,7 @@ public class reverseMorseScript : MonoBehaviour
 
             for (int i = 0; i < parts.Length; i++)
             {
+                if (transmitting) yield return new WaitUntil(() => !transmitting);
                 if (parts[i] == "br") { OnBreakButton(); }
                 else if (parts[i] == "tx") { OnSpaceButton(); }
                 else if (parts[i] == "rs") { OnResetButton(); }


### PR DESCRIPTION
For users who want to input both stages in one line, the next input will now wait until transmitting is done before continuing the next input.